### PR TITLE
Fix Exception when searching without color

### DIFF
--- a/MagicApi/Controllers/SearchController.cs
+++ b/MagicApi/Controllers/SearchController.cs
@@ -49,7 +49,7 @@ namespace MagicApi.Controllers
                 }
             }
 
-            if (query.Colors.Length != 0)
+            if (query.Colors != null && query.Colors.Length != 0)
             {
                 urlParam.AppendFormat("c:{0} ", string.Concat(query.Colors));
             }


### PR DESCRIPTION
Prevent `NullReferenceException` when the `colors` parameter not provided in the `SearchController`'s `ForCard` method.